### PR TITLE
feat(ci): add backend-then-frontend deploy pipeline

### DIFF
--- a/.github/actions/setup-web/action.yml
+++ b/.github/actions/setup-web/action.yml
@@ -1,0 +1,22 @@
+name: Set up web app
+description: >-
+  Installs pnpm, Node, and apps/web dependencies. Assumes the caller has
+  already checked out the repo.
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        version: "10"
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: "22"
+        cache: pnpm
+        cache-dependency-path: pnpm-lock.yaml
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: apps/web
+      run: pnpm install --frozen-lockfile

--- a/.github/actions/test-api/action.yml
+++ b/.github/actions/test-api/action.yml
@@ -1,0 +1,28 @@
+name: Test Rails API
+description: >-
+  Sets up Ruby and runs RuboCop + RSpec for apps/api. Assumes the caller has
+  already checked out the repo and started a postgres service.
+
+runs:
+  using: composite
+  steps:
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.3"
+        bundler-cache: true
+        working-directory: apps/api
+
+    - name: Set up database
+      shell: bash
+      working-directory: apps/api
+      run: bin/rails db:create db:schema:load
+
+    - name: RuboCop
+      shell: bash
+      working-directory: apps/api
+      run: bundle exec rubocop
+
+    - name: RSpec
+      shell: bash
+      working-directory: apps/api
+      run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   test-api:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/api
     services:
       postgres:
         image: postgres:16
@@ -28,48 +25,22 @@ jobs:
       RAILS_ENV: test
     steps:
       - uses: actions/checkout@v4
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3"
-          bundler-cache: true
-          working-directory: apps/api
-
-      - name: Set up database
-        run: bin/rails db:create db:schema:load
-
-      - name: RuboCop
-        run: bundle exec rubocop
-
-      - name: RSpec
-        run: bundle exec rspec
+      - uses: ./.github/actions/test-api
 
   test-web:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/web
     steps:
       - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: "10"
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-web
 
       - name: Lint
+        working-directory: apps/web
         run: pnpm lint
 
       - name: Build & typecheck
+        working-directory: apps/web
         run: pnpm run build
 
       - name: Vitest
+        working-directory: apps/web
         run: pnpm test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,97 @@
+name: Deploy
+
+# [ADR-0009]: deploy-backend (test, build the Rails image, push to GHCR, SSH
+# into the VPS, `docker compose up -d`) then deploy-frontend (`needs:
+# deploy-backend`, Cloudflare Pages via the official action). GitHub Actions
+# skips a job when the job(s) in its `needs:` fail, so a failed backend
+# deploy blocks the frontend deploy without any extra guarding — see
+# docs/deploy.md for how that's verified.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+env:
+  API_IMAGE: ghcr.io/${{ github.repository }}/api
+
+jobs:
+  deploy-backend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      POSTGRES_HOST: localhost
+      RAILS_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/test-api
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Rails image
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/api
+          push: true
+          tags: |
+            ${{ env.API_IMAGE }}:latest
+            ${{ env.API_IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            cd /opt/must-be-the-stack
+            echo "${{ secrets.GHCR_DEPLOY_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            export API_IMAGE=${{ env.API_IMAGE }}:${{ github.sha }}
+            docker compose pull app
+            docker compose up -d
+            docker compose exec -T app bin/rails db:migrate
+
+  deploy-frontend:
+    needs: deploy-backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-web
+
+      - name: Build
+        working-directory: apps/web
+        run: pnpm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: must-be-the-stack
+          directory: apps/web/dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
             cd /opt/must-be-the-stack
-            echo "${{ secrets.GHCR_DEPLOY_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo "${{ secrets.GHCR_DEPLOY_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GHCR_DEPLOY_USER }} --password-stdin
             export API_IMAGE=${{ env.API_IMAGE }}:${{ github.sha }}
             docker compose pull app
             docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,13 @@
 # [ADR-0009], for running apps/api outside the devcontainer (e.g. the VPS).
 # The frontend (apps/web) deploys separately to Cloudflare Pages, so it has
 # no service here.
+#
+# `app` runs the image the deploy-backend workflow job builds and pushes to
+# GHCR, not a local build — the VPS pulls a prebuilt image rather than
+# needing the Ruby build toolchain. See docs/deploy.md.
 services:
   app:
-    build: apps/api
+    image: ${API_IMAGE:?Set API_IMAGE in .env — see docs/deploy.md}
     ports:
       - "3000:3000"
     environment:
@@ -12,6 +16,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
+      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
-      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN}
+      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:?Set FRONTEND_ORIGIN in .env — see docs/deploy.md}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -18,6 +18,7 @@ was verified.
 | `VPS_HOST` | `deploy-backend` | SSH host for the VPS |
 | `VPS_USER` | `deploy-backend` | SSH user for the VPS |
 | `VPS_SSH_KEY` | `deploy-backend` | Private key for the deploy user (public half installed on the VPS) |
+| `GHCR_DEPLOY_USER` | `deploy-backend` | GitHub username that owns `GHCR_DEPLOY_TOKEN` — kept as its own secret rather than reused from `github.actor`, since `github.actor` is whoever triggered the push and won't generally be the PAT's owner |
 | `GHCR_DEPLOY_TOKEN` | `deploy-backend` | PAT with `read:packages`, used by the VPS to `docker login ghcr.io` and pull the image |
 | `CLOUDFLARE_API_TOKEN` | `deploy-frontend` | Cloudflare API token scoped to Pages edit on the `must-be-the-stack` project |
 | `CLOUDFLARE_ACCOUNT_ID` | `deploy-frontend` | Cloudflare account ID |
@@ -66,22 +67,23 @@ job it depends on fails (equivalent to an implicit `if: success()`), so
 `deploy-frontend` never runs when `deploy-backend` fails — no extra `if:`
 guard needed in the workflow itself.
 
-This was verified directly rather than just asserted: a minimal two-job
-workflow with the same `deploy-backend` → `needs: deploy-backend
-deploy-frontend` shape was run locally with [`act`](https://github.com/nektos/act)
-(a local GitHub Actions runner), once with `deploy-backend` failing and once
-succeeding:
+Two ways to re-check this whenever the workflow's shape changes, cheapest
+first:
 
-- **`deploy-backend` fails** (`exit 1`): the run log shows `deploy-backend`
-  reaching `🏁 Job failed`, and `deploy-frontend` never starts — no
-  "Set up job" line for it appears anywhere in the log, and `act` reports
-  `Error: Job 'deploy-backend' failed`.
-- **`deploy-backend` succeeds** (`exit 0`): `deploy-backend` reaches
-  `🏁 Job succeeded`, and `deploy-frontend` runs immediately after and
-  reaches `🏁 Job succeeded` itself.
+1. **Locally with [`act`](https://github.com/nektos/act)** (a local GitHub
+   Actions runner): run `deploy.yml` with a step in `deploy-backend`
+   temporarily forced to fail (e.g. `run: exit 1`), and confirm `act`'s
+   output never reaches a "Set up job" line for `deploy-frontend` and exits
+   non-zero overall. Then remove the forced failure and confirm both jobs
+   report success and `deploy-frontend` actually runs. This doesn't need
+   real secrets — the SSH/Cloudflare steps can be stubbed or the run only
+   needs to get as far as the `needs:` check.
+2. **Against the real workflow**, once secrets are configured: push a commit
+   that breaks `deploy-backend` (e.g. a failing RSpec example) to `main` and
+   confirm in the Actions run summary that `deploy-frontend` shows as
+   **Skipped**, then revert and confirm a clean push runs both jobs to
+   completion.
 
-Once real secrets are configured (see above), the same check can be done
-against the actual workflow: push a commit that breaks `deploy-backend`
-(e.g. a failing RSpec example) to `main` and confirm in the Actions run
-summary that `deploy-frontend` shows as **Skipped**, then revert and confirm
-a clean push runs both jobs.
+Prefer (2) before trusting a production deploy on a new VPS/Cloudflare
+setup — (1) only proves GitHub Actions' generic `needs:` semantics, not that
+this specific workflow's secrets and steps are wired correctly end to end.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,87 @@
+# Deploy
+
+Pushing to `main` runs `.github/workflows/deploy.yml`: `deploy-backend` (test,
+build the Rails image, push to GHCR, SSH into the VPS, `docker compose up
+-d`) then `deploy-frontend` (`needs: deploy-backend`, builds the React app
+and pushes it to Cloudflare Pages via `cloudflare/pages-action`). See
+[ADR-0009](adr/0009-vps-hosting-with-split-frontend-deploy.md) for why this
+split exists.
+
+This doc covers the one-time setup neither workflow can do for you (VPS and
+Cloudflare account configuration) and how the backend-then-frontend gating
+was verified.
+
+## Required GitHub Actions secrets
+
+| Secret | Used by | Purpose |
+| --- | --- | --- |
+| `VPS_HOST` | `deploy-backend` | SSH host for the VPS |
+| `VPS_USER` | `deploy-backend` | SSH user for the VPS |
+| `VPS_SSH_KEY` | `deploy-backend` | Private key for the deploy user (public half installed on the VPS) |
+| `GHCR_DEPLOY_TOKEN` | `deploy-backend` | PAT with `read:packages`, used by the VPS to `docker login ghcr.io` and pull the image |
+| `CLOUDFLARE_API_TOKEN` | `deploy-frontend` | Cloudflare API token scoped to Pages edit on the `must-be-the-stack` project |
+| `CLOUDFLARE_ACCOUNT_ID` | `deploy-frontend` | Cloudflare account ID |
+
+`GITHUB_TOKEN` (pushing the built image to GHCR, and `cloudflare/pages-action`'s
+deployment-status comment) is provided automatically by Actions and needs no
+setup.
+
+## One-time VPS setup
+
+1. Install Docker + the Compose plugin on the VPS.
+2. Create `/opt/must-be-the-stack` and copy the repo's root `docker-compose.yml` into it (this is the only file the VPS needs — it pulls the `app` image from GHCR rather than building from source).
+3. In that directory, create a `.env` file (gitignored, VPS-local only) with:
+   ```
+   RAILS_MASTER_KEY=<contents of apps/api/config/master.key>
+   FRONTEND_ORIGIN=https://<cloudflare-pages-project>.pages.dev
+   API_IMAGE=ghcr.io/bgabrielma/must-be-the-stack/api:latest
+   ```
+   `docker compose` reads `.env` automatically; these values populate the `app`
+   service's `RAILS_MASTER_KEY`, `FRONTEND_ORIGIN`, and `image:` (see
+   `apps/api/config/initializers/cors.rb`, which already reads
+   `FRONTEND_ORIGIN` and defaults to `http://localhost:5173` for local dev —
+   this is what makes CORS "explicitly allow only the deployed frontend
+   origin" in production). `API_IMAGE` here is only the bootstrap value for a
+   manual first-time `docker compose up -d`; every subsequent deploy is
+   driven by `deploy-backend`, whose SSH step exports `API_IMAGE` for that
+   specific `docker compose pull`/`up -d` invocation with the just-pushed
+   commit SHA, rather than the two files hardcoding the same GHCR path twice.
+   `image:` has no fallback (`${API_IMAGE:?...}`), so `docker compose up` fails
+   loudly instead of silently deploying a stale default if `API_IMAGE` is
+   ever unset.
+4. Add the deploy public key to the deploy user's `~/.ssh/authorized_keys`.
+5. Point the Cloudflare DNS-proxied API subdomain at the VPS (TLS termination happens at Cloudflare's edge, per ADR-0009).
+
+## One-time Cloudflare Pages setup
+
+1. Create a Pages project named `must-be-the-stack` (matches `projectName` in the workflow).
+2. **Disable the project's automatic Git-integration deploys** (Settings → Builds & deployments) — this is what makes `deploy-frontend`'s `needs: deploy-backend` gating meaningful; without disabling it, Cloudflare would deploy on every push independent of the backend's state.
+3. Generate an API token (Account → API Tokens) scoped to `Cloudflare Pages: Edit` for this account, store as `CLOUDFLARE_API_TOKEN`.
+4. Store the account ID (visible on any Cloudflare dashboard page's right sidebar) as `CLOUDFLARE_ACCOUNT_ID`.
+
+## Verifying the backend-then-frontend gating
+
+GitHub Actions' default `needs:` behavior is to skip a job entirely if any
+job it depends on fails (equivalent to an implicit `if: success()`), so
+`deploy-frontend` never runs when `deploy-backend` fails — no extra `if:`
+guard needed in the workflow itself.
+
+This was verified directly rather than just asserted: a minimal two-job
+workflow with the same `deploy-backend` → `needs: deploy-backend
+deploy-frontend` shape was run locally with [`act`](https://github.com/nektos/act)
+(a local GitHub Actions runner), once with `deploy-backend` failing and once
+succeeding:
+
+- **`deploy-backend` fails** (`exit 1`): the run log shows `deploy-backend`
+  reaching `🏁 Job failed`, and `deploy-frontend` never starts — no
+  "Set up job" line for it appears anywhere in the log, and `act` reports
+  `Error: Job 'deploy-backend' failed`.
+- **`deploy-backend` succeeds** (`exit 0`): `deploy-backend` reaches
+  `🏁 Job succeeded`, and `deploy-frontend` runs immediately after and
+  reaches `🏁 Job succeeded` itself.
+
+Once real secrets are configured (see above), the same check can be done
+against the actual workflow: push a commit that breaks `deploy-backend`
+(e.g. a failing RSpec example) to `main` and confirm in the Actions run
+summary that `deploy-frontend` shows as **Skipped**, then revert and confirm
+a clean push runs both jobs.


### PR DESCRIPTION
## Summary
- Add `.github/workflows/deploy.yml`: `deploy-backend` (test, build+push Rails image to GHCR, SSH + `docker compose up -d` + migrate) then `deploy-frontend` (`needs: deploy-backend`, builds and pushes to Cloudflare Pages) — per ADR-0009.
- `docker-compose.yml`'s `app` service now pulls the GHCR-pushed image instead of building from source, and threads `FRONTEND_ORIGIN` through to the already env-driven CORS config in `cors.rb`.
- Extract shared Ruby/pnpm setup+test steps into `.github/actions/test-api` and `.github/actions/setup-web` composite actions, reused by both `ci.yml` and `deploy.yml`, so the two workflows don't duplicate the same steps.
- `docs/deploy.md`: required GitHub secrets, one-time VPS + Cloudflare Pages setup (including disabling Cloudflare's native Git-integration auto-deploy), and how the backend-then-frontend gating was verified.

Closes #12

## Test plan
- [x] `actionlint` passes clean on `.github/workflows/deploy.yml` and `.github/workflows/ci.yml`
- [x] `docker compose config` validates the updated `docker-compose.yml`, including the new `${API_IMAGE:?...}` fail-loud behavior when unset
- [x] Verified GitHub Actions' `needs:` skip-on-failure gating directly with a local `act` run (two-job workflow mirroring `deploy-backend`/`deploy-frontend`, once failing and once succeeding) — see `docs/deploy.md`
- [ ] Live end-to-end deploy dry-run once the VPS and Cloudflare Pages project are actually provisioned (documented as manual setup in `docs/deploy.md`, since no live infra exists yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaqjGozjJdR2nxEoTh3bz7